### PR TITLE
avoid deprecation warning when installing pyrfr

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ env:
     -rap
 
 # todo: Lint with flake8
-# todo: install extra requirements
 # todo: tests conda
 # todo: coverage
 jobs:
@@ -42,6 +41,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install --upgrade wheel setuptools
         pip install ".${{ env.extra-requires }}"
     - name: Run tests
       run: |


### PR DESCRIPTION
In test action, `pip install pyrfr` caused deprecation warning on macos and windows:
```
  DEPRECATION: pyrfr is being installed using the legacy 'setup.py install' method, because 
it does not have a 'pyproject.toml' and the 'wheel' package is not installed. pip 23.1 will enforce 
this behaviour change. A possible replacement is to enable the '--use-pep517' option. Discussion 
can be found at https://github.com/pypa/pip/issues/8559
  Running setup.py install for pyrfr: started
  Running setup.py install for pyrfr: still running...
  Running setup.py install for pyrfr: finished with status 'done'
```

So install `wheel` before installing pyrfr to silence the warning:
```bash
pip install --upgrade wheel setuptools
```
